### PR TITLE
Feat: GH-9 (#9)

### DIFF
--- a/nuxt/components/organisms/ArtworkSlider.vue
+++ b/nuxt/components/organisms/ArtworkSlider.vue
@@ -99,7 +99,7 @@ const { findByCategory } = artworkStore;
 <style scoped lang="scss">
 .artwork-slider {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr min-content;
   grid-template-rows: var(--space-12) auto 1fr;
   grid-template-areas:
     'header action'
@@ -159,6 +159,7 @@ const { findByCategory } = artworkStore;
     padding: var(--space-2);
     font-size: var(--font-size-xsm);
     font-weight: var(--font-weight-light);
+    text-wrap: nowrap;
   }
 }
 

--- a/strapi/src/api/categories/controllers/categories.js
+++ b/strapi/src/api/categories/controllers/categories.js
@@ -8,8 +8,8 @@ module.exports = {
 
       const { getCategories, transformCategories } = strapi.service('api::categories.categories');
 
-      const categories = await getCategories(categoryQuery, endpointUrl);
-      ctx.body = await transformCategories(categories);
+      const { results } = await getCategories(categoryQuery, endpointUrl);
+      ctx.body = await transformCategories(results.bindings);
     } catch (err) {
       ctx.body = err;
     }

--- a/strapi/src/api/items/controllers/items.js
+++ b/strapi/src/api/items/controllers/items.js
@@ -16,14 +16,14 @@ module.exports = {
         return;
       }
 
-      const items = await getItemsByCategory(
+      const { results } = await getItemsByCategory(
         itemsQuery,
         endpointUrl,
         categoryMeta.uri,
         parseInt(page) || 0,
         parseInt(limit) || 16,
       );
-      ctx.body = await transformItems(categoryId, items);
+      ctx.body = await transformItems(categoryId, results.bindings);
     } catch (err) {
       ctx.body = err;
     }


### PR DESCRIPTION
resolves #9 

Now all requests use the following headers
```
'Content-Type': 'application/sparql-query'
'Accept': 'application/sparql-results+json'
```